### PR TITLE
Add monochrome icon definition

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/cic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/cic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/cic_launcher_background"/>
     <foreground android:drawable="@drawable/cic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/cic_launcher_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
Since the regular icon foreground is monochrome, I just pointed to that, and it seems to work fine.